### PR TITLE
Extra course list functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# rcanvas 0.9.2
+
+* Added two function, `get_term_course_list()` and `get_account_course_list()`.
+* `get_term_course_list()` gathers a list of all courses in a specific term.
+* `get_account_course_list()` gathers a list of all courses for an account or sub-account
+
 # rcanvas 0.9.1
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/course-data.R
+++ b/R/course-data.R
@@ -28,6 +28,22 @@ get_course_list <- function(user_id = NULL, include = NULL) {
   return(unique(dat))
 }
 
+get_account_course_list <- function(acc_id = NULL, include = NULL) {
+  if (!is.null(acc_id)) {
+    url <- paste0(canvas_url(), paste("accounts", acc_id, "courses", sep = "/"))
+  } else {
+    url <- paste0(canvas_url(), "courses")
+  }
+  args <- list(
+    per_page = 100,
+    acc_id = acc_id
+  )
+  include <- iter_args_list(include, "include[]")
+  args <- c(args, include)
+  dat <- process_response(url, args)
+  return(unique(dat))
+}
+
 #' @title Function to return course analytics data.
 #'
 #' @description Returns a data.frame of course analytics data. Note: if an individual's user_id is specified,

--- a/R/course-data.R
+++ b/R/course-data.R
@@ -44,6 +44,22 @@ get_account_course_list <- function(acc_id = NULL, include = NULL) {
   return(unique(dat))
 }
 
+get_term_course_list <- function(term_id = NULL, acc_id = NULL, include = NULL) {
+  if (!is.null(term_id)) {
+    url <- paste0(canvas_url(), paste("accounts/", acc_id, "/courses?enrollment_term_id=", term_id, sep = "" ))
+  } else {
+    url <- paste0(canvas_url(), paste("accounts", acc_id, "courses", sep = "/"))
+  }
+  args <- list(
+    per_page = 100,
+    term_id = term_id
+  )
+  include <- iter_args_list(include, "include[]")
+  args <- c(args, include)
+  dat <- process_response(url, args)
+  return(unique(dat))
+}
+
 #' @title Function to return course analytics data.
 #'
 #' @description Returns a data.frame of course analytics data. Note: if an individual's user_id is specified,

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,7 @@ canvas_query <- function(urlx, args, type = "GET") {
   fun <- getFromNamespace(type, "httr")
   args <- sc(args)
   resp <- fun(urlx,
-              httr::user_agent("rcanvas - https://github.com/daranzolin/rcanvas"),
+              httr::user_agent("rcanvas - https://github.com/Yasshin/rcanvas"),
               httr::add_headers(Authorization = paste("Bearer", check_token())),
               query = args)
   httr::stop_for_status(resp)


### PR DESCRIPTION
I added two functions that would allow one to get a course list by either term, account or sub-account. The function referenced was `get_course_list()`