### PR TITLE
Use file.path for update_wpage

### DIFF
--- a/R/pages.R
+++ b/R/pages.R
@@ -147,7 +147,7 @@ create_wpage <- function(course_id, title, body, editing_roles = "teachers", pub
 update_wpage <- function(course_id, page_url, title = NULL, body = NULL, editing_roles = "teachers", published = FALSE, notify = FALSE){
  # PUT /api/v1/courses/:course_id/pages/:url
   # wiki_page[front_page]		    boolean	Set an unhidden page as the front page (if true)
-  url <- paste0(canvas_url(), file.path("courses", course_id, "pages", page_url))
+  url <- file.path(canvas_url(), file.path("courses", course_id, "pages", page_url))
   args_list <- list(`wiki_page[editing_roles]` = editing_roles,
                     `wiki_page[published]` = published,
                     `wiki_page[notify_of_update]` = notify,


### PR DESCRIPTION
Wonderful package! I use Rmarkdown to create my syllabus and can now use `update_wpage` to put all the pages up on canvas. Really nice!

I found a (very) minor issue with `update_wpage` however. `canvas_url()` returns `https://my-canvas-site/api/v1` so the `url` becomes something like `https://my-canvas-site/api/v1courses/123/pages/my-page`. Note the missing `/` between `v1` and `courses`. Using `file.path` would fix this.